### PR TITLE
Update pay-terminal port to 3001 and enhance logging

### DIFF
--- a/payment-system/docker-compose.yml
+++ b/payment-system/docker-compose.yml
@@ -109,17 +109,21 @@ services:
       dockerfile: Dockerfile
     container_name: payment-terminal
     ports:
-      - "8888:3000"
+      - "8888:3001"
+      - "${PORT:-50006}:3001"
     environment:
       - REACT_APP_API_URL=http://localhost:8082/payproc
       - REACT_APP_PAY_PROC_USERNAME=payproc
       - REACT_APP_PAY_PROC_PASSWORD=ProcPass123!
+      - PORT=3001
+    volumes:
+      - /workspace/payment-system.log:/workspace/payment-system.log
     networks:
       - payment-network
     depends_on:
       - pay-proc
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8888"]
+      test: ["CMD", "curl", "-f", "http://localhost:3001"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
This PR makes the following changes to the pay-terminal service:

1. Changes the port from 3000 to 3001 in server.js, dev-server.js, Dockerfile, and docker-compose.yml

2. Enhances logging to write all log messages to the external file /workspace/payment-system.log:
   - Creates a custom logger that writes to both console and file
   - Overrides console.log, console.error, and console.warn to use the custom logger
   - Updates the /api/log endpoint to support different log levels (INFO, WARN, ERROR)
   - Adds additional system information logging at server startup